### PR TITLE
Lagt til egen gruppe for CREATE på topics

### DIFF
--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Oneshot.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Oneshot.kt
@@ -236,6 +236,7 @@ fun Routing.registerOneshotApi(adminClient: AdminClient, fasit: FasitProperties)
 }
 
 fun KafkaGroupType.into(): AclOperation = when (this) {
+    KafkaGroupType.CONNECT -> AclOperation.CREATE
     KafkaGroupType.PRODUCER -> AclOperation.WRITE
     else -> AclOperation.READ
 }

--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
@@ -189,6 +189,7 @@ fun Routing.createNewTopic(adminClient: AdminClient, config: FasitProperties) =
                                             principal,
                                             host,
                                             when (kafkaGroup.type) {
+                                                KafkaGroupType.CONNECT -> AclOperation.CREATE
                                                 KafkaGroupType.PRODUCER -> AclOperation.WRITE
                                                 KafkaGroupType.CONSUMER -> AclOperation.READ
                                                 else -> AclOperation.READ // should never be here

--- a/src/main/kotlin/no/nav/integrasjon/ldap/LDAPGroup.kt
+++ b/src/main/kotlin/no/nav/integrasjon/ldap/LDAPGroup.kt
@@ -358,11 +358,13 @@ class LDAPGroup(private val config: FasitProperties) :
 
 /**
  * Enum class KafkaGroupType with LDAP group prefix included
- * Each topic has 2 groups
+ * Each topic has 3 groups
  * - a producer group with members allowed to produce events to topic
  * - a consumer group with members allowed to consume events from topic
+ * - a connect group with members allowed to create on topic
  */
 enum class KafkaGroupType(val prefix: String) {
+    @SerializedName("CONNECT") CONNECT("CO-"),
     @SerializedName("PRODUCER") PRODUCER("KP-"),
     @SerializedName("CONSUMER") CONSUMER("KC-"),
     @SerializedName("MANAGER") MANAGER("KM-")


### PR DESCRIPTION
Denne PR'en løser problemet mitt med at Kafka Connect ikke får koblet seg til topicsene mine når jeg bruker de to gruppene vi allerede støtter, og jeg mener at det er fordi jeg mangler `CREATE` på topic-nivå.

Kafka Connect krever rettigheten DESCRIBE,WRITE,READ, og CREATE på topics.
Min forståelse av dette er at dette ikke gir meg rettighet til å lage nye topics.

Det jeg ikke har helt forstått er forskjellen på disse to:
cluster
> Adding ACLs for resource `Cluster:LITERAL:kafka-cluster`:

og topic
> Adding ACLs for resource `Topic:LITERAL:di-connect-offsets`:

Nedenfor er kommandoen jeg endte opp med å kjøre mot mitt lokal navkafka-cluster:
```
--producer                                 Convenience option to add/remove ACLs
                                           for producer role. This will
                                           generate ACLs that allows WRITE,
                                           DESCRIBE and CREATE on topic.
```
Rettigheter Kafka Connect trenger:
https://docs.confluent.io/current/connect/security.html#worker-acl-requirements

ACL-format:
https://docs.confluent.io/current/kafka/authorization.html#acl-format