### PR TITLE
Added endpoint for creating ACLs for streams apps

### DIFF
--- a/src/main/kotlin/no/nav/integrasjon/KtorServer.kt
+++ b/src/main/kotlin/no/nav/integrasjon/KtorServer.kt
@@ -36,6 +36,7 @@ import no.nav.integrasjon.api.v1.groupsAPI
 import no.nav.integrasjon.api.v1.aclAPI
 import no.nav.integrasjon.api.v1.apigwAPI
 import no.nav.integrasjon.api.v1.registerOneshotApi
+import no.nav.integrasjon.api.v1.streamsAPI
 import no.nav.integrasjon.ldap.LDAPAuthenticate
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.AdminClient
@@ -150,6 +151,7 @@ fun Application.kafkaAdminREST() {
 
         // provide the essential, management of kafka environment, topic creation and authorization
 
+        streamsAPI(adminClient, fasitProps)
         registerOneshotApi(adminClient, fasitProps)
         topicsAPI(adminClient, fasitProps)
         brokersAPI(adminClient, fasitProps)

--- a/src/main/kotlin/no/nav/integrasjon/api/v1/CommonElementsAPI.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/CommonElementsAPI.kt
@@ -4,8 +4,8 @@ import io.ktor.application.ApplicationCall
 import io.ktor.application.application
 import io.ktor.application.call
 import io.ktor.http.HttpStatusCode
-import io.ktor.util.pipeline.PipelineContext
 import io.ktor.response.respond
+import io.ktor.util.pipeline.PipelineContext
 import no.nav.integrasjon.EXCEPTION
 import no.nav.integrasjon.FasitProperties
 import no.nav.integrasjon.api.nais.client.SERVICES_ERR_K
@@ -30,6 +30,9 @@ internal const val GROUPS = "$API_V1/groups"
 // route for topics in kafka environment, and zoom into related acls and groups per topic
 internal const val TOPICS = "$API_V1/topics"
 internal const val ONESHOT = "$API_V1/oneshot"
+
+// Route for streams
+internal const val STREAMS = "$API_V1/streams"
 
 // Route for apigw
 internal const val APIGW = "$API_V1/apigw"

--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Streams.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Streams.kt
@@ -1,0 +1,72 @@
+package no.nav.integrasjon.api.v1
+
+import io.ktor.application.call
+import io.ktor.http.HttpStatusCode
+import io.ktor.locations.Location
+import io.ktor.response.respond
+import io.ktor.routing.Routing
+import no.nav.integrasjon.FasitProperties
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.BasicAuthSecurity
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.Group
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.badRequest
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.ok
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.post
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.securityAndReponds
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.serviceUnavailable
+import no.nav.integrasjon.api.nielsfalk.ktor.swagger.unAuthorized
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.common.acl.AccessControlEntry
+import org.apache.kafka.common.acl.AclBinding
+import org.apache.kafka.common.acl.AclOperation
+import org.apache.kafka.common.acl.AclPermissionType
+import org.apache.kafka.common.resource.PatternType
+import org.apache.kafka.common.resource.ResourcePattern
+import org.apache.kafka.common.resource.ResourceType
+import java.util.concurrent.TimeUnit
+
+private const val swGroup = "Streams"
+
+enum class PostStreamStatus {
+    ERROR,
+    OK
+}
+
+@Group(swGroup)
+@Location("$STREAMS/")
+class PostStream
+data class PostStreamBody(val applicationName: String, val user: String)
+
+data class PostStreamResponse(val status: PostStreamStatus, val message: String)
+
+fun Routing.streamsAPI(adminClient: AdminClient?, fasitConfig: FasitProperties) {
+    post<PostStream, PostStreamBody>(
+            "new streams app. The stream app will get permissions to create new internal topics."
+                    .securityAndReponds(
+                            BasicAuthSecurity(),
+                            ok<PostStreamResponse>(),
+                            serviceUnavailable<AnError>(),
+                            badRequest<AnError>(),
+                            unAuthorized<Unit>()
+                    )
+    ) { _, body ->
+        val streamsAcl = AclBinding(
+                ResourcePattern(ResourceType.TOPIC, body.applicationName, PatternType.PREFIXED),
+                AccessControlEntry("User:${body.user}", "*", AclOperation.ALL, AclPermissionType.ALLOW)
+        )
+
+        try {
+            adminClient?.createAcls(listOf(streamsAcl))?.all()?.get(fasitConfig.kafkaTimeout, TimeUnit.MILLISECONDS)
+            log.info("Successfully updated acl for stream app ${body.applicationName}")
+            call.respond(PostStreamResponse(
+                    status = PostStreamStatus.OK,
+                    message = "Successfully updated ACL"
+            ))
+        } catch (e: Exception) {
+            log.error("Exception caught while updating ACL for stream app ${body.applicationName}", e)
+            call.respond(HttpStatusCode.ServiceUnavailable, PostStreamResponse(
+                    status = PostStreamStatus.ERROR,
+                    message = "Failed to update ACL"
+            ))
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Streams.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Streams.kt
@@ -52,7 +52,7 @@ fun Routing.streamsAPI(adminClient: AdminClient?, fasitConfig: FasitProperties) 
         adminClient?.listTopics()?.names()?.get(fasitConfig.kafkaTimeout, TimeUnit.MILLISECONDS)?.filter {
             it.startsWith(body.applicationName)
         }?.firstOrNull()?.let {
-            log.error("Trying to register a stream app which is a prefix of ${it}")
+            log.error("Trying to register a stream app which is a prefix of $it")
             call.respond(HttpStatusCode.BadRequest, PostStreamResponse(
                     status = PostStreamStatus.ERROR,
                     message = "Stream name is prefix of a topic"

--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Streams.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Streams.kt
@@ -49,13 +49,19 @@ fun Routing.streamsAPI(adminClient: AdminClient?, fasitConfig: FasitProperties) 
                             unAuthorized<Unit>()
                     )
     ) { _, body ->
-        val streamsAcl = AclBinding(
-                ResourcePattern(ResourceType.TOPIC, body.applicationName, PatternType.PREFIXED),
-                AccessControlEntry("User:${body.user}", "*", AclOperation.ALL, AclPermissionType.ALLOW)
+        val streamsAcl = listOf(
+                AclBinding(
+                    ResourcePattern(ResourceType.TOPIC, body.applicationName, PatternType.PREFIXED),
+                    AccessControlEntry("User:${body.user}", "*", AclOperation.ALL, AclPermissionType.ALLOW)
+            ),
+            AclBinding(
+                    ResourcePattern(ResourceType.GROUP, body.applicationName, PatternType.PREFIXED),
+                    AccessControlEntry("User:${body.user}", "*", AclOperation.ALL, AclPermissionType.ALLOW)
+            )
         )
 
         try {
-            adminClient?.createAcls(listOf(streamsAcl))?.all()?.get(fasitConfig.kafkaTimeout, TimeUnit.MILLISECONDS)
+            adminClient?.createAcls(streamsAcl)?.all()?.get(fasitConfig.kafkaTimeout, TimeUnit.MILLISECONDS)
             log.info("Successfully updated acl for stream app ${body.applicationName}")
             call.respond(PostStreamResponse(
                     status = PostStreamStatus.OK,

--- a/src/test/kotlin/no/nav/integrasjon/test/KafkaAdminRestSpec.kt
+++ b/src/test/kotlin/no/nav/integrasjon/test/KafkaAdminRestSpec.kt
@@ -39,11 +39,15 @@ import no.nav.integrasjon.api.v1.NAIS_ISALIVE
 import no.nav.integrasjon.api.v1.NAIS_ISREADY
 import no.nav.integrasjon.api.v1.ONESHOT
 import no.nav.integrasjon.api.v1.OneshotCreationRequest
+import no.nav.integrasjon.api.v1.PostStreamBody
+import no.nav.integrasjon.api.v1.PostStreamResponse
+import no.nav.integrasjon.api.v1.PostStreamStatus
 import no.nav.integrasjon.api.v1.PostTopicBody
 import no.nav.integrasjon.api.v1.PostTopicModel
 import no.nav.integrasjon.api.v1.PutApiGwResultModel
 import no.nav.integrasjon.api.v1.PutTopicConfigEntryBody
 import no.nav.integrasjon.api.v1.RoleMember
+import no.nav.integrasjon.api.v1.STREAMS
 import no.nav.integrasjon.api.v1.TOPICS
 import no.nav.integrasjon.api.v1.TopicCreation
 import no.nav.integrasjon.kafkaAdminREST
@@ -348,6 +352,28 @@ object KafkaAdminRestSpec : Spek({
 
                 context("Route $ACLS") {
                     // don't bother :-)
+                }
+
+                context("Route $STREAMS") {
+                    context("Create streams app ACLs") {
+                        it("should create ACL for streams app") {
+                            val call = handleRequest(HttpMethod.Post, "$STREAMS/") {
+                                addHeader(HttpHeaders.Accept, "application/json")
+                                addHeader(HttpHeaders.ContentType, "application/json")
+                                addHeader(HttpHeaders.Authorization, "Basic ${encodeBase64("n000002:itest2".toByteArray())}")
+                                setBody(Gson().toJson(PostStreamBody("team1-streams-app1", "team1")))
+                            }
+
+                            println(call.response.content)
+
+                            val result: PostStreamResponse = Gson().fromJson(
+                                    call.response.content ?: "",
+                                    object : TypeToken<PostStreamResponse>() {}.type)
+
+                            call.response.status() shouldBe HttpStatusCode.OK
+                            result.status shouldBe PostStreamStatus.OK
+                        }
+                    }
                 }
 
                 context("Route $BROKERS") {


### PR DESCRIPTION
I'm not quite sure of this works out-of-the-box, but I think it's a good starter.

The endpoint requires the `application.id` of the stream app and the service user the app uses to authenticate. 