### PR TITLE
Support adding config 'min.compaction.lag.ms' setting for compacted t…

### DIFF
--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
@@ -457,7 +457,8 @@ enum class AllowedConfigEntries(val entryName: String) {
     RETENTION_MS("retention.ms"),
     RETENTION_BYTES("retention.bytes"),
     CLEANUP_POLICY("cleanup.policy"),
-    DELETE_RETENTION_MS("delete.retention.ms")
+    DELETE_RETENTION_MS("delete.retention.ms"),
+    MIN_COMPACTION_LAG_MS("min.compaction.lag.ms")
 }
 
 @Group(swGroup)

--- a/src/test/kotlin/no/nav/integrasjon/test/KafkaAdminRestSpec.kt
+++ b/src/test/kotlin/no/nav/integrasjon/test/KafkaAdminRestSpec.kt
@@ -647,6 +647,28 @@ object KafkaAdminRestSpec : Spek({
                                 call.response.status() shouldBe HttpStatusCode.OK
                             }
 
+                            it("should update 'min.compaction.lag.ms' configuration for topic tpc-03") {
+                                val call = handleRequest(HttpMethod.Put, "$TOPICS/tpc-03") {
+                                    addHeader(HttpHeaders.Accept, "application/json")
+                                    addHeader(HttpHeaders.ContentType, "application/json")
+                                    // relevant user is in the right place in UserAndGroups.ldif
+                                    addHeader(
+                                            HttpHeaders.Authorization,
+                                            "Basic ${encodeBase64("n145821:itest3".toByteArray())}"
+                                    )
+
+                                    val jsonPayload = Gson().toJson(ConfigEntries(listOf(
+                                            PutTopicConfigEntryBody(
+                                                    AllowedConfigEntries.MIN_COMPACTION_LAG_MS,
+                                                    "3600000"
+                                            )
+
+                                    )))
+                                    setBody(jsonPayload)
+                                }
+                                call.response.status() shouldBe HttpStatusCode.OK
+                            }
+
                             it("should return updated 'delete.retention.ms' configuration for tpc-03 and should not have reset configurations for 'retention.ms'") {
                                 val call = handleRequest(HttpMethod.Get, "$TOPICS/tpc-03") {
                                     addHeader(HttpHeaders.Accept, "application/json")


### PR DESCRIPTION
…opics.

 'min.compaction.lag.ms'  --> 'The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted' (https://kafka.apache.org/documentation/#compaction)