### PR TITLE
Control topic creation via env-variable

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -37,3 +37,6 @@ spec:
       memory: 128Mi
   vault:
     enabled: true
+  env:
+    - name: TOPIC_CREATION_ENABLED
+      value: "true"

--- a/src/main/kotlin/no/nav/integrasjon/Environment.kt
+++ b/src/main/kotlin/no/nav/integrasjon/Environment.kt
@@ -27,7 +27,8 @@ data class Environment(
     val ldapCommon: LdapCommon = LdapCommon(),
     val ldapAuthenticate: LdapAuthenticate = LdapAuthenticate(),
     val ldapGroup: LdapGroup = LdapGroup(),
-    val ldapUser: LdapUser = LdapUser()
+    val ldapUser: LdapUser = LdapUser(),
+    val flags: Flags = Flags()
 ) {
     data class Kafka(
         val kafkaBrokers: String = config[Key("kafka.brokers", stringType)],
@@ -93,6 +94,10 @@ data class Environment(
     data class LdapUser(
         val ldapUser: String = config[Key("ldap.user", stringType)],
         val ldapPassword: String = config[Key("ldap.password", stringType)]
+    )
+
+    data class Flags(
+        val topicCreationEnabled: Boolean = System.getenv("TOPIC_CREATION_ENABLED") == "true"
     )
 
     // Return diverse distinguished name types

--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
@@ -192,6 +192,16 @@ fun Routing.createNewTopic(adminClient: AdminClient?, environment: Environment) 
         application.environment.log.info(logEntry)
 
         /**
+         * Rule 0 - topic creation must be enabled
+         */
+        if (!environment.flags.topicCreationEnabled) {
+            val msg = "topic creation has been disabled"
+            application.environment.log.warn(msg)
+            call.respond(HttpStatusCode.ServiceUnavailable, AnError(msg))
+            return@post
+        }
+
+        /**
          * Rule 1 - user must exist in current ldap environment in order to be part of group KM-<topic>
          */
 

--- a/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
+++ b/src/main/kotlin/no/nav/integrasjon/api/v1/Topics.kt
@@ -197,7 +197,7 @@ fun Routing.createNewTopic(adminClient: AdminClient?, environment: Environment) 
         if (!environment.flags.topicCreationEnabled) {
             val msg = "topic creation has been disabled"
             application.environment.log.warn(msg)
-            call.respond(HttpStatusCode.ServiceUnavailable, AnError(msg))
+            call.respond(HttpStatusCode.Forbidden, AnError(msg))
             return@post
         }
 


### PR DESCRIPTION
In preparation for disabling topic creation after june 1st, make it possible to switch it on and off via environment variable.